### PR TITLE
Add possibility to report only when action has failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ For `if` parameter, see
 | nocontext | No | `true` or `false` | `false` | Set `true` to suppress GitHub context fields (`Repository`, `Ref`, etc). |
 | noprefix | No | `true` or `false` | `false` | Set `true` to avoid appending job status (`Success: `, etc.) to title |
 | nodetail | No | `true` or `false` | `false` | Set `true` will set both `nocontext` and `noprefix` to `true` |
+| report_only_failures | No | `true` or `false` | `false` | Set to `true` will report only when status is not `succeeded` |
 
 ### Deprecated inputs
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: "Suppress detailed embed fields"
     required: false
     default: 'false'
+  report_only_failures:
+    description: "When set to true, does not send webhook if status is `success`"
+    required: false
+    default: 'false'
 
 runs:
   using: 'node12'

--- a/src/input.ts
+++ b/src/input.ts
@@ -12,6 +12,7 @@ export interface Inputs {
     avatar_url: string
     nocontext: boolean
     noprefix: boolean
+    report_only_failures: boolean
 }
 
 interface StatusOption {
@@ -62,7 +63,8 @@ export function getInputs(): Inputs {
         username: core.getInput('username').trim(),
         avatar_url: core.getInput('avatar_url').trim(),
         nocontext: nocontext,
-        noprefix: noprefix
+        noprefix: noprefix,
+        report_only_failures: stob(core.getInput("report_only_failures"))
     }
 
     // validate

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,11 +17,24 @@ async function run() {
             logInfo(JSON.stringify(payload, null, 2))
         endGroup()
 
+        if (!shouldReportWebook(inputs)) {
+            logInfo(`Not triggering ${inputs.webhooks.length} webhook${inputs.webhooks.length>1 ? 's' : ''}, because of report_only_failures `)
+            return
+        }
+
         logInfo(`Triggering ${inputs.webhooks.length} webhook${inputs.webhooks.length>1 ? 's' : ''}...`)
+
         await Promise.all(inputs.webhooks.map(w => wrapWebhook(w.trim(), payload)))
     } catch(e) {
         logError(`Unexpected failure: ${e} (${e.message})`)
     }
+}
+
+export function shouldReportWebook(inputs: Inputs): boolean {
+    if (inputs.status !== "success")
+        return true
+
+    return !(inputs.report_only_failures && inputs.status === "success");
 }
 
 function wrapWebhook(webhook: string, payload: Object): Promise<void> {

--- a/test/input.test.ts
+++ b/test/input.test.ts
@@ -15,11 +15,13 @@ describe("getInputs()", () => {
         delete process.env['INPUT_COLOR']
         delete process.env['INPUT_USERNAME']
         delete process.env['INPUT_AVATAR_URL']
+        delete process.env['INPUT_REPORT_FAILURES']
 
         // see action.yml for default values
         process.env['INPUT_STATUS'] = 'success'
         process.env['INPUT_NOFAIL'] = 'true'
         process.env['INPUT_NODETAIL'] = 'false'
+        process.env['INPUT_REPORT_FAILURES'] = 'false'
 
         process.env['DISCORD_WEBHOOK'] = "https://env.webhook.invalid"
     })
@@ -36,6 +38,7 @@ describe("getInputs()", () => {
         expect(got.color).toBeFalsy()
         expect(got.username).toBe('')
         expect(got.avatar_url).toBe('')
+        expect(got.report_only_failures).toBe(false)
     })
 
     test("no webhooks", () => {
@@ -86,6 +89,7 @@ describe("getInputs()", () => {
         process.env['INPUT_COLOR'] = '0xffffff'
         process.env['INPUT_USERNAME'] = 'jest test'
         process.env['INPUT_AVATAR_URL'] = '\n\n\nhttps://avatar.webhook.invalid\n'
+        process.env['INPUT_REPORT_ONLY_FAILURES'] = 'false'
 
         const got = getInputs()
         expect(got.noprefix).toBe(true)
@@ -100,6 +104,7 @@ describe("getInputs()", () => {
         expect(got.color).toBe(0xffffff)
         expect(got.username).toBe('jest test')
         expect(got.avatar_url).toBe('https://avatar.webhook.invalid')
+        expect(got.report_only_failures).toBe(false)
     })
 
     test("all (title)", () => {
@@ -112,6 +117,7 @@ describe("getInputs()", () => {
         process.env['INPUT_COLOR'] = '0xffffff'
         process.env['INPUT_USERNAME'] = 'jest test'
         process.env['INPUT_AVATAR_URL'] = '\n\n\nhttps://avatar.webhook.invalid\n'
+        process.env['INPUT_REPORT_FAILURES'] = 'false'
 
         const got = getInputs()
         expect(got.noprefix).toBe(true)
@@ -127,5 +133,6 @@ describe("getInputs()", () => {
         expect(got.color).toBe(0xffffff)
         expect(got.username).toBe('jest test')
         expect(got.avatar_url).toBe('https://avatar.webhook.invalid')
+        expect(got.report_only_failures).toBe(false)
     })
 })

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,6 +1,6 @@
 import { formatEvent } from '../src/format'
 import { Inputs } from '../src/input'
-import { getPayload } from '../src/main'
+import {getPayload, shouldReportWebook} from '../src/main'
 
 jest.mock('@actions/github', () => {
     return {
@@ -35,7 +35,8 @@ describe('getPayload(Inputs)', () => {
         image: '',
         color: NaN,
         username: '',
-        avatar_url: ''
+        avatar_url: '',
+        report_only_failures: false
     }
 
     test("default", () => {
@@ -297,6 +298,7 @@ describe('getPayload(Inputs)', () => {
                 ]
             }]
         }
+        expect(getPayload(inputs)).toStrictEqual(want)
     })
 
     test("color", () => {
@@ -425,5 +427,46 @@ describe('getPayload(Inputs)', () => {
             avatar_url: "https://avatar.invalid/avatar.png"
         }
         expect(getPayload(inputs)).toStrictEqual(want)
+    })
+
+    test("on success, when report only failure is set to false - send a webhook", () => {
+        const inputs: Inputs = {
+            ...baseInputs,
+            report_only_failures: false,
+            status: "success"
+        }
+
+        expect(shouldReportWebook(inputs)).toBe(true)
+
+    })
+
+    test("on success, when report only failure is set to true - don't send a webhook", () => {
+        const inputs: Inputs = {
+            ...baseInputs,
+            report_only_failures: true,
+            status: "success"
+        }
+
+        expect(shouldReportWebook(inputs)).toBe(false)
+
+    })
+    test("on failure, when report only failure is set to false - send a webhook", () => {
+        const inputs: Inputs = {
+            ...baseInputs,
+            report_only_failures: false,
+            status: "not a success"
+        }
+
+        expect(shouldReportWebook(inputs)).toBe(true)
+    })
+
+    test("on failure, when report only failure is set to true - send a webhook", () => {
+        const inputs: Inputs = {
+            ...baseInputs,
+            report_only_failures: true,
+            status: "not a success"
+        }
+
+        expect(shouldReportWebook(inputs)).toBe(true)
     })
 })


### PR DESCRIPTION
Hey!

I've added a possibility to report only successes. My use case is where when I'm triggering this action for multiple pull requests, I don't necessarily want to see failures from all branches on the same channel. Another use case is when there is an action to run tests on default branch after merge, they rarely should break; but the merges occur somewhat often and clutter the channel.

What do you think?