### PR TITLE
fix workflowURL with runNumber

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           commit_message: |
             Automatic build
             Commit ${{ github.sha }}
-            Run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            Run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_number }}
 
       - name: Update source tag
         shell: bash

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,9 +41,9 @@ function wrapWebhook(webhook: string, payload: Object): Promise<void> {
 export function getPayload(inputs: Readonly<Inputs>): Object {
     const ctx = github.context
     const { owner, repo } = ctx.repo
-    const { eventName, ref, workflow, actor, payload, serverUrl, runId } = ctx
+    const { eventName, ref, workflow, actor, payload, serverUrl, runNumber } = ctx
     const repoURL = `${serverUrl}/${owner}/${repo}`
-    const workflowURL = `${repoURL}/actions/runs/${runId}`
+    const workflowURL = `${repoURL}/actions/runs/${runNumber}`
 
     logDebug(JSON.stringify(payload))
 

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -14,7 +14,7 @@ jest.mock('@actions/github', () => {
             ref: 'refs/tags/simple-tag',
             workflow: 'push-ci',
             actor: 'Codertocat',
-            runId: 123123,
+            runNumber: 123123,
             serverUrl: "https://githubactions.serverurl.example.com",
 
             repo: {


### PR DESCRIPTION
I made a mistake in #446, we should use `runNumber` instead of `runId` to get the correct run link.