### PR TITLE
fix: Sample code in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ Some fields support markdown syntax.
   with:
     webhook: ${{ secrets.DISCORD_WEBHOOK }}
     nodetail: true
-    title: New version of `software` is ready!
+    title: "New version of `software` is ready!"
     description: |
-      Version `1.2.3-alpha`
-      Click [here](https://github.com/sarisia/actions-status-discord) to download!
+      Version `${{ github.event.release.tag_name }}`
+      Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download!
+    color: 0xff91a4
 ```
 
 ![image](https://user-images.githubusercontent.com/33576079/212482315-52429bbd-b7b9-456a-8ee8-ee26aa2a0fb1.png)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Post GitHub Actions status to Discord as an beautiful embed
   with:
     webhook: ${{ secrets.DISCORD_WEBHOOK }}
     nodetail: true
-    title: "New version of `software` is ready!
+    title: "New version of `software` is ready!"
     description: |
       Version `${{ github.event.release.tag_name }}`
       Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download!

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Some fields support markdown syntax.
     title: "New version of `software` is ready!"
     description: |
       Version `${{ github.event.release.tag_name }}`
-      Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download!
+      Click [here](${{ github.event.release.html_url }}) to download!
     color: 0xff91a4
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Post GitHub Actions status to Discord as an beautiful embed
     title: "New version of `software` is ready!"
     description: |
       Version `${{ github.event.release.tag_name }}`
-      Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download!
+      Click [here](${{ github.event.release.html_url }}) to download!
     color: 0xff91a4
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Post GitHub Actions status to Discord as an beautiful embed
     color: 0xff91a4
 ```
 
-![image](https://user-images.githubusercontent.com/33576079/212482315-52429bbd-b7b9-456a-8ee8-ee26aa2a0fb1.png)
+![image](https://github.com/user-attachments/assets/ac102998-6bf4-451b-9803-91ff083ad9b6)
 
 For `if` parameter, see
 [GitHub Actions Reference](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Post GitHub Actions status to Discord as an beautiful embed
     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
   with:
     nodetail: true
-    title: "We did it!"
+    title: "App ${{ github.event.release.tag_name }} has been released!"
+    description: |
+      Download it from [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }})!
     color: 0xff91a4
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ Post GitHub Actions status to Discord as an beautiful embed
 ```yaml
 - uses: sarisia/actions-status-discord@v1
   if: always()
-  env:
-    DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
   with:
+    webhook: ${{ secrets.DISCORD_WEBHOOK }}
     nodetail: true
     title: "New version of `software` is ready!
     description: |

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Post GitHub Actions status to Discord as an beautiful embed
     color: 0xff91a4
 ```
 
-![image](https://github.com/user-attachments/assets/ac102998-6bf4-451b-9803-91ff083ad9b6)
+![image](https://user-images.githubusercontent.com/33576079/212482315-52429bbd-b7b9-456a-8ee8-ee26aa2a0fb1.png)
 
 For `if` parameter, see
 [GitHub Actions Reference](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions)

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Post GitHub Actions status to Discord as an beautiful embed
     DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
   with:
     nodetail: true
-    title: "App ${{ github.event.release.tag_name }} has been released!"
+    title: "New version of `software` is ready!
     description: |
-      Download it from [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }})!
+      Version `${{ github.event.release.tag_name }}`
+      Click [here]( ${{github.event.repository.html_url }}/releases/tag/${{ github.event.release.tag_name }}) to download!
     color: 0xff91a4
 ```
 


### PR DESCRIPTION
The sample code for `nodetail` did not match the corresponding image (which is the same image as the markdown example). This PR makes the code match what is in the image. Additionally, I updated the sample code in the markdown example to be dynamic, since this can actually be used in a real scenerio.

I tested my new sample code and it matches the images currently in the README:

![image](https://github.com/user-attachments/assets/be4008db-0422-4c1d-b38b-830201879512)

Also, I opened a [feature request](https://github.com/sarisia/actions-status-discord/discussions/547) regarding support for the transparent embed color.